### PR TITLE
bimanual launch file, reverse_port collision fixed

### DIFF
--- a/launch/bimanual_bringup.launch
+++ b/launch/bimanual_bringup.launch
@@ -1,0 +1,37 @@
+<launch>
+ 
+ <group ns="left">
+   <arg name="limited" default="false"/>
+   <arg name="robot_ip" default="10.10.11.64"/>
+   <arg name="min_payload"  default="0.0"/>
+   <arg name="max_payload"  default="5.0"/>
+   <arg name="prefix" default="left_" />
+   <arg name="reverse_port" default="50005"/>   
+  <include file="$(find ur_modern_driver)/launch/ur5e_bringup.launch">
+   <arg name="limited" value="$(arg limited)"/>
+   <arg name="robot_ip" value="$(arg robot_ip)"/>
+   <arg name="reverse_port" value="$(arg reverse_port)"/>
+   <arg name="min_payload"  value="$(arg min_payload)"/>
+   <arg name="max_payload"  value="$(arg max_payload)"/>
+   <arg name="prefix" value="$(arg prefix)"/>
+  </include>
+ </group>
+ 
+ <group ns="right">
+   <arg name="limited" default="false"/>
+   <arg name="robot_ip" default="10.10.11.38"/>
+   <arg name="min_payload"  default="0.0"/>
+   <arg name="max_payload"  default="5.0"/>
+   <arg name="prefix" default="right_" />
+   <arg name="reverse_port" default="50006"/>   
+  <include file="$(find ur_modern_driver)/launch/ur5e_bringup.launch">
+   <arg name="limited" value="$(arg limited)"/>
+   <arg name="robot_ip" value="$(arg robot_ip)"/>
+   <arg name="reverse_port" value="$(arg reverse_port)"/>
+   <arg name="min_payload"  value="$(arg min_payload)"/>
+   <arg name="max_payload"  value="$(arg max_payload)"/>
+   <arg name="prefix" value="$(arg prefix)"/>
+  </include>
+ </group>
+ 
+</launch>

--- a/launch/ur5e_bringup.launch
+++ b/launch/ur5e_bringup.launch
@@ -10,7 +10,7 @@
 
   <!-- robot_ip: IP-address of the robot's socket-messaging server -->
   <arg name="robot_ip"/>
-  <arg name="reverse_port" default="50002"/>
+  <arg name="reverse_port" default="50001"/>
   <arg name="limited" default="false"/>
   <arg name="min_payload"  default="0.0"/>
   <arg name="max_payload"  default="5.0"/>

--- a/launch/ur5e_bringup.launch
+++ b/launch/ur5e_bringup.launch
@@ -10,6 +10,7 @@
 
   <!-- robot_ip: IP-address of the robot's socket-messaging server -->
   <arg name="robot_ip"/>
+  <arg name="reverse_port" default="50002"/>
   <arg name="limited" default="false"/>
   <arg name="min_payload"  default="0.0"/>
   <arg name="max_payload"  default="5.0"/>
@@ -33,6 +34,7 @@
   <!-- ur common -->
   <include file="$(find ur_modern_driver)/launch/ur_common.launch">
     <arg name="robot_ip" value="$(arg robot_ip)"/>
+    <arg name="reverse_port" value="$(arg reverse_port)"/>
     <arg name="min_payload"  value="$(arg min_payload)"/>
     <arg name="max_payload"  value="$(arg max_payload)"/>
     <arg name="prefix"  value="$(arg prefix)" />

--- a/launch/ur5e_bringup_compatible.launch
+++ b/launch/ur5e_bringup_compatible.launch
@@ -10,6 +10,7 @@
 
   <!-- robot_ip: IP-address of the robot's socket-messaging server -->
   <arg name="robot_ip"/>
+  <arg name="reverse_port" default="50001"/>
   <arg name="limited" default="false"/>
   <arg name="min_payload"  default="0.0"/>
   <arg name="max_payload"  default="5.0"/>

--- a/launch/ur5e_bringup_joint_limited.launch
+++ b/launch/ur5e_bringup_joint_limited.launch
@@ -10,6 +10,7 @@
 
   <!-- robot_ip: IP-address of the robot's socket-messaging server -->
   <arg name="robot_ip"/>
+  <arg name="reverse_port" default="50001"/>
   <arg name="min_payload"  default="0.0"/>
   <arg name="max_payload"  default="5.0"/>
   <arg name="prefix" default="" />

--- a/launch/ur5e_ros_control.launch
+++ b/launch/ur5e_ros_control.launch
@@ -7,6 +7,7 @@
   <arg     if="$(arg debug)" name="launch_prefix" value="gdb --ex run --args" />
 
   <arg name="robot_ip"/>
+  <arg name="reverse_port" default="50001" />
   <arg name="limited" default="false"/>
   <arg name="min_payload"  default="0.0"/>
   <arg name="max_payload"  default="3.0"/>
@@ -24,6 +25,7 @@
   <!-- Load hardware interface -->
   <node name="ur_hardware_interface" pkg="ur_modern_driver" type="ur_driver" output="log" launch-prefix="$(arg launch_prefix)">
     <param name="robot_ip_address" type="str" value="$(arg robot_ip)"/>
+    <param name="reverse_port" type="int" value="$(arg reverse_port)" />
     <param name="min_payload" type="double" value="$(arg min_payload)"/>
     <param name="max_payload" type="double" value="$(arg max_payload)"/>
     <param name="max_velocity" type="double" value="$(arg max_velocity)"/>

--- a/launch/ur_common.launch
+++ b/launch/ur_common.launch
@@ -9,7 +9,7 @@
 <launch>
   <!-- robot_ip: IP-address of the robot's socket-messaging server -->
   <arg name="robot_ip" />
-  <arg name="reverse_port" default="50002" />
+  <arg name="reverse_port" default="50001" />
   <arg name="min_payload" />
   <arg name="max_payload" />
   <arg name="prefix" default="" />

--- a/launch/ur_common.launch
+++ b/launch/ur_common.launch
@@ -9,6 +9,7 @@
 <launch>
   <!-- robot_ip: IP-address of the robot's socket-messaging server -->
   <arg name="robot_ip" />
+  <arg name="reverse_port" default="50002" />
   <arg name="min_payload" />
   <arg name="max_payload" />
   <arg name="prefix" default="" />
@@ -38,6 +39,7 @@
   <!-- copy the specified IP address to be consistant with ROS-Industrial spec. -->
     <param name="prefix" type="str" value="$(arg prefix)" />
     <param name="robot_ip_address" type="str" value="$(arg robot_ip)" />
+    <param name="reverse_port" type="int" value="$(arg reverse_port)" />
     <param name="use_ros_control" type="bool" value="$(arg use_ros_control)"/>
     <param name="use_lowbandwidth_trajectory_follower" type="bool" value="$(arg use_lowbandwidth_trajectory_follower)"/>
     <param name="min_payload" type="double" value="$(arg min_payload)" />


### PR DESCRIPTION
If you want to connect to multiple arms, you need these changes to prevent collision on the reverse_port. Should probably apply similar changes to all files where robot_ip is specified.